### PR TITLE
fix(debugger): replace sendMessage with devtool eval

### DIFF
--- a/debugger.js
+++ b/debugger.js
@@ -34,12 +34,12 @@ var DebuggerComponent = React.createClass({
       this.setState(JSON.parse(message));
     }.bind(this));
 
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new Event("cerebral.dev.requestUpdate");window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'var event = new Event("cerebral.dev.requestUpdate");window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
-
   },
   render: function () {
     var currentSignalIndex = this.state.currentSignalIndex;

--- a/debugger/mutation.js
+++ b/debugger/mutation.js
@@ -35,18 +35,20 @@ var MutationComponent = React.createClass({
         path: path
       }
     };
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new CustomEvent("cerebral.dev.logPath", ' + JSON.stringify(detail) + ');window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'var event = new CustomEvent("cerebral.dev.logPath", ' + JSON.stringify(detail) + ');window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
   },
   logArg: function(argString, event) {
     event.preventDefault();
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'console.log(JSON.parse(\'' + argString + '\'))',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'console.log(JSON.parse(\'' + argString + '\'))';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
   },
   renderMutationArg: function(mutationArg, index) {

--- a/debugger/signal.js
+++ b/debugger/signal.js
@@ -49,10 +49,11 @@ var ValueStyle = {
 var SignalComponent = React.createClass({
   logValue: function (valueString, event) {
     event.preventDefault();
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'console.log(JSON.parse(\'' + valueString + '\'))',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'console.log(JSON.parse(\'' + valueString + '\'))';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
   },
   renderValue: function (value) {

--- a/debugger/slider.js
+++ b/debugger/slider.js
@@ -20,12 +20,13 @@ function debounce(fn, delay) {
 
 var SliderComponent = React.createClass({
   remember: function (index) {
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new CustomEvent("cerebral.dev.remember", {detail: ' + (index - 1) + '});window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
-    });
-    this.props.optimisticRangeUpdate(index);
+    var src = 'var event = new CustomEvent("cerebral.dev.remember", {detail: ' + (index - 1) + '});window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
+      this.props.optimisticRangeUpdate(index);
+    }.bind(this));
   },
   render: function() {
     return DOM.div({

--- a/debugger/toolbar.js
+++ b/debugger/toolbar.js
@@ -48,10 +48,11 @@ var ToolbarComponent = React.createClass({
     });
   },
   toggleKeepState: function () {
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new Event("cerebral.dev.toggleKeepState");window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'var event = new Event("cerebral.dev.toggleKeepState");window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
   },
   optimisticRangeUpdate: function (index) {
@@ -60,42 +61,48 @@ var ToolbarComponent = React.createClass({
     });
   },
   resetStore: function () {
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new Event("cerebral.dev.resetStore");window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'var event = new Event("cerebral.dev.resetStore");window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
   },
   logModel: function () {
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new Event("cerebral.dev.logModel");window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
+    var src = 'var event = new Event("cerebral.dev.logModel");window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
     });
   },
   logComputedPath: function (event) {
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new CustomEvent("cerebral.dev.logComputedPath", {detail: ' + JSON.stringify(this.props.computedPaths[event.target.value - 1]) + '});window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
-    });
-    this.forceUpdate();
+    var src = 'var event = new CustomEvent("cerebral.dev.logComputedPath", {detail: ' + JSON.stringify(this.props.computedPaths[event.target.value - 1]) + '});window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
+      this.forceUpdate();
+    }.bind(this));
   },
   remember: function (change) {
     var index = this.state.stepValue + change;
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new CustomEvent("cerebral.dev.remember", {detail: ' + (index - 1) + '});window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
-    });
-    this.optimisticRangeUpdate(index);
+    var src = 'var event = new CustomEvent("cerebral.dev.remember", {detail: ' + (index - 1) + '});window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
+      this.optimisticRangeUpdate(index);
+    }.bind(this));
   },
   toggleDisabled: function () {
-    chrome.extension.sendMessage({
-      action: 'code',
-      content: 'var event = new Event("cerebral.dev.toggleDisableDebugger");window.dispatchEvent(event);',
-      tabId: chrome.devtools.inspectedWindow.tabId
-    });
+    var src =  'var event = new Event("cerebral.dev.toggleDisableDebugger");window.dispatchEvent(event);';
+    chrome.devtools.inspectedWindow.eval(src, function(res, err) {
+      if (err) {
+        console.log(err);
+      }
+      this.optimisticRangeUpdate(index);
+    }.bind(this));
   },
   renderComputed(path, index) {
     return DOM.option({


### PR DESCRIPTION
Fix for https://github.com/cerebral/cerebral-chrome-extension/issues/12

I had a look at react's extension, which does not have this issue. The way they send an eval'd message did not use the tab Id (which I'm suspecting is maybe being duplicated..?)

See: https://github.com/facebook/react-devtools/blob/master/shells/chrome/src/inject.js

I've replaced most calls to sendMessage with a `chrome.devtools.inspectedWindow.eval` alternative. There are a few other calls to `chrome.tabs.sendMessage` that I have no replaced, as I'm not sure of what changing them could do.
